### PR TITLE
ScalaCheck Renaming Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.class
 *.log
+target

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # scalatestplus-scalafix
 Auto-fixing error due to version upgrade, good practice etc.
+
+This project took inspiration from: 
+
+https://github.com/olafurpg/named-literal-arguments

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,54 @@
+lazy val V = _root_.scalafix.sbt.BuildInfo
+inThisBuild(
+  List(
+    organization := "org.scalatest",
+    homepage := Some(url("https://github.com/olafurpg/named-literal-arguments")),
+    licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+    developers := List(
+      Developer(
+        "bvenners",
+        "Bill Venners",
+        "bill@artima.com",
+        url("https://www.artima.com")
+      )
+    ),
+    scalaVersion := V.scala212,
+    addCompilerPlugin(scalafixSemanticdb),
+    scalacOptions ++= List(
+      "-Yrangepos"
+    )
+  )
+)
+
+skip in publish := true
+
+lazy val rules = project.settings(
+  moduleName := "named-literal-arguments",
+  libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % V.scalafixVersion
+)
+
+lazy val input = project.settings(
+  skip in publish := true,
+  libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.6-SNAP-for-scalafix",
+  libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.14.0"
+)
+
+lazy val output = project.settings(
+  skip in publish := true,
+  libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.6-SNAP-for-scalafix",
+  libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.14.0"
+)
+
+lazy val tests = project
+  .settings(
+    skip in publish := true,
+    libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.scalafixVersion % Test cross CrossVersion.full,
+    scalafixTestkitOutputSourceDirectories :=
+      sourceDirectories.in(output, Compile).value,
+    scalafixTestkitInputSourceDirectories :=
+      sourceDirectories.in(input, Compile).value,
+    scalafixTestkitInputClasspath :=
+      fullClasspath.in(input, Compile).value
+  )
+  .dependsOn(rules)
+  .enablePlugins(ScalafixTestkitPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val V = _root_.scalafix.sbt.BuildInfo
 inThisBuild(
   List(
     organization := "org.scalatest",
-    homepage := Some(url("https://github.com/olafurpg/named-literal-arguments")),
+    homepage := Some(url("https://github.com/scalatest/scalatestplus-scalafix")),
     licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
     developers := List(
       Developer(

--- a/input/src/main/scala/test/RenameCheckersSpec.scala
+++ b/input/src/main/scala/test/RenameCheckersSpec.scala
@@ -1,0 +1,14 @@
+/*
+rule = RenamePackage
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.prop.Checkers
+
+class RenameCheckersSpec extends FunSuite with Checkers {
+  
+  test("test concat") {
+    check((a: List[Int], b: List[Int]) => a.size + b.size == (a ::: b).size)
+  }
+}

--- a/input/src/main/scala/test/RenameCheckersSpec2.scala
+++ b/input/src/main/scala/test/RenameCheckersSpec2.scala
@@ -1,0 +1,19 @@
+/*
+rule = RenamePackage
+NoLiteralArguments.disabledLiterals = [
+  Int
+  String
+  Boolean
+]
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.check._
+
+class RenameCheckersSpec2 extends FunSuite with Checkers {
+  
+  test("test concat") {
+    check((a: List[Int], b: List[Int]) => a.size + b.size == (a ::: b).size)
+  }
+}

--- a/input/src/main/scala/test/RenameCheckersSpec2.scala
+++ b/input/src/main/scala/test/RenameCheckersSpec2.scala
@@ -1,15 +1,10 @@
 /*
 rule = RenamePackage
-NoLiteralArguments.disabledLiterals = [
-  Int
-  String
-  Boolean
-]
  */
 package test
 
 import org.scalatest._
-import org.scalatest.check._
+import org.scalatest.prop._
 
 class RenameCheckersSpec2 extends FunSuite with Checkers {
   

--- a/input/src/main/scala/test/RenameCheckersSpec3.scala
+++ b/input/src/main/scala/test/RenameCheckersSpec3.scala
@@ -1,0 +1,14 @@
+/*
+rule = RenamePackage
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.prop.{Checkers, PropertyChecks}
+
+class RenameCheckersSpec3 extends FunSuite with Checkers {
+  
+  test("test concat") {
+    check((a: List[Int], b: List[Int]) => a.size + b.size == (a ::: b).size)
+  }
+}

--- a/input/src/main/scala/test/RenameGeneratorDrivenPropertyChecksSpec.scala
+++ b/input/src/main/scala/test/RenameGeneratorDrivenPropertyChecksSpec.scala
@@ -1,0 +1,16 @@
+/*
+rule = RenamePackage
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
+class RenameGeneratorDrivenPropertyChecksSpec extends FunSuite with GeneratorDrivenPropertyChecks with Matchers {
+
+  test("testing") {
+    forAll { (a: String) =>
+      assert(a.length < 0)
+    }
+  }
+}

--- a/input/src/main/scala/test/RenameGeneratorDrivenPropertyChecksSpec2.scala
+++ b/input/src/main/scala/test/RenameGeneratorDrivenPropertyChecksSpec2.scala
@@ -1,0 +1,16 @@
+/*
+rule = RenamePackage
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.prop._
+
+class RenameGeneratorDrivenPropertyChecksSpec2 extends FunSuite with GeneratorDrivenPropertyChecks with Matchers {
+
+  test("testing") {
+    forAll { (a: String) =>
+      assert(a.length < 0)
+    }
+  }
+}

--- a/input/src/main/scala/test/RenameGeneratorDrivenPropertyChecksSpec3.scala
+++ b/input/src/main/scala/test/RenameGeneratorDrivenPropertyChecksSpec3.scala
@@ -1,0 +1,16 @@
+/*
+rule = RenamePackage
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.prop.{Checkers, GeneratorDrivenPropertyChecks}
+
+class RenameGeneratorDrivenPropertyChecksSpec3 extends FunSuite with GeneratorDrivenPropertyChecks with Matchers {
+
+  test("testing") {
+    forAll { (a: String) =>
+      assert(a.length < 0)
+    }
+  }
+}

--- a/input/src/main/scala/test/RenamePropertyChecksSpec.scala
+++ b/input/src/main/scala/test/RenamePropertyChecksSpec.scala
@@ -1,0 +1,16 @@
+/*
+rule = RenamePackage
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.prop.PropertyChecks
+
+class RenamePropertyChecksSpec extends FunSuite with PropertyChecks with Matchers {
+
+  test("testing") {
+    forAll { (a: String) =>
+      assert(a.length < 0)
+    }
+  }
+}

--- a/input/src/main/scala/test/RenamePropertyChecksSpec2.scala
+++ b/input/src/main/scala/test/RenamePropertyChecksSpec2.scala
@@ -1,0 +1,16 @@
+/*
+rule = RenamePackage
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.prop._
+
+class RenamePropertyChecksSpec2 extends FunSuite with PropertyChecks with Matchers {
+
+  test("testing") {
+    forAll { (a: String) =>
+      assert(a.length < 0)
+    }
+  }
+}

--- a/input/src/main/scala/test/RenamePropertyChecksSpec3.scala
+++ b/input/src/main/scala/test/RenamePropertyChecksSpec3.scala
@@ -1,0 +1,16 @@
+/*
+rule = RenamePackage
+ */
+package test
+
+import org.scalatest._
+import org.scalatest.prop.{Checkers, PropertyChecks}
+
+class RenamePropertyChecksSpec3 extends FunSuite with PropertyChecks with Matchers {
+
+  test("testing") {
+    forAll { (a: String) =>
+      assert(a.length < 0)
+    }
+  }
+}

--- a/output/src/main/scala/test/RenameCheckersSpec.scala
+++ b/output/src/main/scala/test/RenameCheckersSpec.scala
@@ -1,0 +1,12 @@
+
+package test
+
+import org.scalatest._
+import org.scalatest.check.Checkers
+
+class RenameCheckersSpec extends FunSuite with Checkers {
+  
+  test("test concat") {
+    check((a: List[Int], b: List[Int]) => a.size + b.size == (a ::: b).size)
+  }
+}

--- a/output/src/main/scala/test/RenameCheckersSpec2.scala
+++ b/output/src/main/scala/test/RenameCheckersSpec2.scala
@@ -1,7 +1,8 @@
 package test
 
 import org.scalatest._
-import org.scalatest.check._
+import org.scalatest.prop._
+import org.scalatest.check.Checkers
 
 class RenameCheckersSpec2 extends FunSuite with Checkers {
   

--- a/output/src/main/scala/test/RenameCheckersSpec2.scala
+++ b/output/src/main/scala/test/RenameCheckersSpec2.scala
@@ -1,0 +1,11 @@
+package test
+
+import org.scalatest._
+import org.scalatest.check._
+
+class RenameCheckersSpec2 extends FunSuite with Checkers {
+  
+  test("test concat") {
+    check((a: List[Int], b: List[Int]) => a.size + b.size == (a ::: b).size)
+  }
+}

--- a/output/src/main/scala/test/RenameCheckersSpec3.scala
+++ b/output/src/main/scala/test/RenameCheckersSpec3.scala
@@ -1,0 +1,11 @@
+package test
+
+import org.scalatest._
+import org.scalatest.check.Checkers
+
+class RenameCheckersSpec3 extends FunSuite with Checkers {
+  
+  test("test concat") {
+    check((a: List[Int], b: List[Int]) => a.size + b.size == (a ::: b).size)
+  }
+}

--- a/output/src/main/scala/test/RenameGeneratorDrivenPropertyChecksSpec.scala
+++ b/output/src/main/scala/test/RenameGeneratorDrivenPropertyChecksSpec.scala
@@ -1,0 +1,14 @@
+
+package test
+
+import org.scalatest._
+import org.scalatest.check.ScalaCheckDrivenPropertyChecks
+
+class RenameGeneratorDrivenPropertyChecksSpec extends FunSuite with ScalaCheckDrivenPropertyChecks with Matchers {
+
+  test("testing") {
+    forAll { (a: String) =>
+      assert(a.length < 0)
+    }
+  }
+}

--- a/output/src/main/scala/test/RenameGeneratorDrivenPropertyChecksSpec2.scala
+++ b/output/src/main/scala/test/RenameGeneratorDrivenPropertyChecksSpec2.scala
@@ -1,0 +1,14 @@
+package test
+
+import org.scalatest._
+import org.scalatest.prop._
+import org.scalatest.check.ScalaCheckDrivenPropertyChecks
+
+class RenameGeneratorDrivenPropertyChecksSpec2 extends FunSuite with ScalaCheckDrivenPropertyChecks with Matchers {
+
+  test("testing") {
+    forAll { (a: String) =>
+      assert(a.length < 0)
+    }
+  }
+}

--- a/output/src/main/scala/test/RenameGeneratorDrivenPropertyChecksSpec3.scala
+++ b/output/src/main/scala/test/RenameGeneratorDrivenPropertyChecksSpec3.scala
@@ -1,0 +1,13 @@
+package test
+
+import org.scalatest._
+import org.scalatest.check.ScalaCheckDrivenPropertyChecks
+
+class RenameGeneratorDrivenPropertyChecksSpec3 extends FunSuite with ScalaCheckDrivenPropertyChecks with Matchers {
+
+  test("testing") {
+    forAll { (a: String) =>
+      assert(a.length < 0)
+    }
+  }
+}

--- a/output/src/main/scala/test/RenamePropertyChecksSpec.scala
+++ b/output/src/main/scala/test/RenamePropertyChecksSpec.scala
@@ -1,0 +1,14 @@
+
+package test
+
+import org.scalatest._
+import org.scalatest.check.ScalaCheckPropertyChecks
+
+class RenamePropertyChecksSpec extends FunSuite with ScalaCheckPropertyChecks with Matchers {
+
+  test("testing") {
+    forAll { (a: String) =>
+      assert(a.length < 0)
+    }
+  }
+}

--- a/output/src/main/scala/test/RenamePropertyChecksSpec2.scala
+++ b/output/src/main/scala/test/RenamePropertyChecksSpec2.scala
@@ -1,0 +1,14 @@
+package test
+
+import org.scalatest._
+import org.scalatest.prop._
+import org.scalatest.check.ScalaCheckPropertyChecks
+
+class RenamePropertyChecksSpec2 extends FunSuite with ScalaCheckPropertyChecks with Matchers {
+
+  test("testing") {
+    forAll { (a: String) =>
+      assert(a.length < 0)
+    }
+  }
+}

--- a/output/src/main/scala/test/RenamePropertyChecksSpec3.scala
+++ b/output/src/main/scala/test/RenamePropertyChecksSpec3.scala
@@ -1,0 +1,13 @@
+package test
+
+import org.scalatest._
+import org.scalatest.check.ScalaCheckPropertyChecks
+
+class RenamePropertyChecksSpec3 extends FunSuite with ScalaCheckPropertyChecks with Matchers {
+
+  test("testing") {
+    forAll { (a: String) =>
+      assert(a.length < 0)
+    }
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,3 @@
+resolvers += Resolver.sonatypeRepo("releases")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.6.0-M19")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")

--- a/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,0 +1,1 @@
+fix.RenamePackage

--- a/rules/src/main/scala/fix/RenamePackage.scala
+++ b/rules/src/main/scala/fix/RenamePackage.scala
@@ -1,0 +1,17 @@
+package fix
+
+import metaconfig.Configured
+import scalafix.v1._
+import scala.meta._
+
+class RenamePackage extends SemanticRule("RenamePackage") {
+
+  override def fix(implicit doc: SemanticDocument): Patch = {
+    Patch.replaceSymbols(
+      "org.scalatest.prop.Checkers" -> "org.scalatest.check.Checkers", 
+      "org.scalatest.prop.PropertyChecks" -> "org.scalatest.check.ScalaCheckPropertyChecks",
+      "org.scalatest.prop.GeneratorDrivenPropertyChecks" -> "org.scalatest.check.ScalaCheckDrivenPropertyChecks"
+    )
+  }
+
+}

--- a/tests/src/test/scala/fix/RuleSuite.scala
+++ b/tests/src/test/scala/fix/RuleSuite.scala
@@ -1,0 +1,7 @@
+package fix
+
+import scalafix.testkit.SemanticRuleSuite
+
+class RuleSuite extends SemanticRuleSuite() {
+  runAllTests()
+}


### PR DESCRIPTION
Initial version that rename scalacheck-related classes to new package.