### PR TITLE
Fix wrong dependency version in README

### DIFF
--- a/3.0.x/README.md
+++ b/3.0.x/README.md
@@ -16,7 +16,7 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.4")
   - Add the following settings to your `build.sbt` or, if you don't have a `build.sbt`:
   
 ```
-scalafixDependencies in ThisBuild += "org.scalatest" %% "autofix-3.0.8" % "1.0.0" 
+scalafixDependencies in ThisBuild += "org.scalatest" %% "autofix-3.0.8" % "1.0.0-SNAP1" 
 
 addCompilerPlugin(scalafixSemanticdb) // enable SemanticDB
 ``` 


### PR DESCRIPTION
1.0.0 doesn't seem to exist, only 1.0.0-SNAP1: https://mvnrepository.com/artifact/org.scalatest/autofix-3.0.8_2.12